### PR TITLE
Phase 2: Notification System

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -6,8 +6,8 @@ import sys
 import config
 from commands.configs import settings
 from commands.event import manage, register, responses, create, list
-from commands.user import timezone
-from core import auth, utils, events, userdata, bulletins, logging as bot_logging
+from commands.user import timezone, notifications as notif_commands
+from core import auth, utils, events, userdata, bulletins, notifications, logging as bot_logging
 
 # =============================================================================
 # Validate Configuration
@@ -141,11 +141,11 @@ async def viewtimezone(interaction: discord.Interaction):
             ephemeral=True
         )
 
-@tree.command(name="remindme", description="Schedule a DM reminder for your event", guild=guild)
+@tree.command(name="remindme", description="Set up notifications for an event", guild=guild)
 @app_commands.describe(event_name="The name of the event you want to be reminded for.")
 async def remindme(interaction: discord.Interaction, event_name: str):
-    """Command to set a DM reminder for an event."""
-    await responses.build_overlap_summary(interaction, event_name, interaction.guild_id)
+    """Command to configure notification preferences for an event."""
+    await notif_commands.show_notification_settings(interaction, event_name)
 
 # ============================================================
 #                        BOT EVENTS
@@ -164,6 +164,10 @@ async def on_ready():
         logger.info("Slash commands synced globally (may take up to 1 hour to propagate)")
 
     await bulletins.restore_bulletin_views(client)
+
+    # Start notification scheduler
+    notifications.init_scheduler(client)
+
     logger.info("Bot is ready!")
 
 

--- a/commands/user/notifications.py
+++ b/commands/user/notifications.py
@@ -1,0 +1,313 @@
+"""
+Notification commands and UI for users.
+
+Allows users to manage their notification preferences for events.
+"""
+import discord
+from discord.ui import View, Button, Select
+from typing import Optional
+
+from core import notifications, events
+from core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+# =============================================================================
+# Reminder Time Options
+# =============================================================================
+
+REMINDER_OPTIONS = [
+    (15, "15 minutes before"),
+    (30, "30 minutes before"),
+    (60, "1 hour before"),
+    (120, "2 hours before"),
+    (1440, "1 day before"),
+]
+
+
+# =============================================================================
+# Views
+# =============================================================================
+
+class NotificationSettingsView(View):
+    """View for configuring notification settings for an event."""
+
+    def __init__(
+        self,
+        user_id: int,
+        guild_id: int,
+        event_name: str,
+        current_pref: Optional[notifications.NotificationPreference] = None
+    ):
+        super().__init__(timeout=180)
+        self.user_id = user_id
+        self.guild_id = guild_id
+        self.event_name = event_name
+
+        # Current settings (or defaults)
+        self.reminder_minutes = current_pref.reminder_minutes if current_pref else 60
+        self.notify_on_start = current_pref.notify_on_start if current_pref else True
+        self.notify_on_change = current_pref.notify_on_change if current_pref else True
+        self.notify_on_cancel = current_pref.notify_on_cancel if current_pref else True
+        self.is_enabled = current_pref is not None
+
+        self._build_components()
+
+    def _build_components(self):
+        self.clear_items()
+
+        # Reminder time select
+        options = [
+            discord.SelectOption(
+                label=label,
+                value=str(minutes),
+                default=(minutes == self.reminder_minutes)
+            )
+            for minutes, label in REMINDER_OPTIONS
+        ]
+
+        reminder_select = Select(
+            placeholder="Reminder time",
+            options=options,
+            custom_id="reminder_time",
+            row=0
+        )
+        reminder_select.callback = self._on_reminder_change
+        self.add_item(reminder_select)
+
+        # Toggle buttons for notification types
+        self.add_item(ToggleButton(
+            "Event Start",
+            self.notify_on_start,
+            "toggle_start",
+            row=1
+        ))
+        self.add_item(ToggleButton(
+            "Event Changes",
+            self.notify_on_change,
+            "toggle_change",
+            row=1
+        ))
+        self.add_item(ToggleButton(
+            "Event Canceled",
+            self.notify_on_cancel,
+            "toggle_cancel",
+            row=1
+        ))
+
+        # Save/Cancel buttons
+        self.add_item(Button(
+            label="Save Preferences",
+            style=discord.ButtonStyle.success,
+            custom_id="save",
+            row=2
+        ))
+
+        if self.is_enabled:
+            self.add_item(Button(
+                label="Disable Notifications",
+                style=discord.ButtonStyle.danger,
+                custom_id="disable",
+                row=2
+            ))
+
+    async def _on_reminder_change(self, interaction: discord.Interaction):
+        self.reminder_minutes = int(interaction.data["values"][0])
+        self._build_components()
+        await interaction.response.edit_message(view=self)
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id != self.user_id:
+            await interaction.response.send_message(
+                "This isn't your notification settings!",
+                ephemeral=True
+            )
+            return False
+
+        custom_id = interaction.data.get("custom_id", "")
+
+        if custom_id == "toggle_start":
+            self.notify_on_start = not self.notify_on_start
+            self._build_components()
+            await interaction.response.edit_message(view=self)
+            return False
+
+        if custom_id == "toggle_change":
+            self.notify_on_change = not self.notify_on_change
+            self._build_components()
+            await interaction.response.edit_message(view=self)
+            return False
+
+        if custom_id == "toggle_cancel":
+            self.notify_on_cancel = not self.notify_on_cancel
+            self._build_components()
+            await interaction.response.edit_message(view=self)
+            return False
+
+        if custom_id == "save":
+            await self._save_preferences(interaction)
+            return False
+
+        if custom_id == "disable":
+            await self._disable_notifications(interaction)
+            return False
+
+        return True
+
+    async def _save_preferences(self, interaction: discord.Interaction):
+        pref = notifications.NotificationPreference(
+            user_id=self.user_id,
+            guild_id=self.guild_id,
+            event_name=self.event_name,
+            reminder_minutes=self.reminder_minutes,
+            notify_on_start=self.notify_on_start,
+            notify_on_change=self.notify_on_change,
+            notify_on_cancel=self.notify_on_cancel,
+        )
+        notifications.set_notification_preference(pref)
+
+        reminder_label = next(
+            (label for mins, label in REMINDER_OPTIONS if mins == self.reminder_minutes),
+            f"{self.reminder_minutes} minutes before"
+        )
+
+        await interaction.response.edit_message(
+            content=(
+                f"✅ **Notifications enabled for {self.event_name}!**\n\n"
+                f"⏰ Reminder: {reminder_label}\n"
+                f"🎉 Event Start: {'✅' if self.notify_on_start else '❌'}\n"
+                f"📝 Event Changes: {'✅' if self.notify_on_change else '❌'}\n"
+                f"❌ Event Canceled: {'✅' if self.notify_on_cancel else '❌'}"
+            ),
+            view=None
+        )
+        self.stop()
+
+    async def _disable_notifications(self, interaction: discord.Interaction):
+        notifications.remove_notification_preference(
+            self.user_id,
+            self.guild_id,
+            self.event_name
+        )
+
+        await interaction.response.edit_message(
+            content=f"🔕 Notifications disabled for **{self.event_name}**.",
+            view=None
+        )
+        self.stop()
+
+
+class ToggleButton(Button):
+    """A button that toggles between enabled/disabled states."""
+
+    def __init__(self, label: str, enabled: bool, custom_id: str, row: int):
+        emoji = "✅" if enabled else "❌"
+        style = discord.ButtonStyle.success if enabled else discord.ButtonStyle.secondary
+
+        super().__init__(
+            label=f"{emoji} {label}",
+            style=style,
+            custom_id=custom_id,
+            row=row
+        )
+
+
+# =============================================================================
+# Command Handlers
+# =============================================================================
+
+async def show_notification_settings(
+    interaction: discord.Interaction,
+    event_name: str
+):
+    """
+    Show notification settings for an event.
+
+    Called from /remindme command or NotifyMe button.
+    """
+    guild_id = interaction.guild_id
+    user_id = interaction.user.id
+
+    # Verify event exists
+    event_matches = events.get_events(guild_id, event_name)
+    if not event_matches:
+        await interaction.response.send_message(
+            f"❌ Event `{event_name}` not found.",
+            ephemeral=True
+        )
+        return
+
+    if len(event_matches) > 1:
+        # Multiple matches - show list
+        event_list = "\n".join(f"• {name}" for name in event_matches.keys())
+        await interaction.response.send_message(
+            f"Multiple events match `{event_name}`:\n{event_list}\n\n"
+            f"Please use the exact event name.",
+            ephemeral=True
+        )
+        return
+
+    # Get exact event name
+    exact_name = list(event_matches.keys())[0]
+    event = event_matches[exact_name]
+
+    # Get current preference if exists
+    current_pref = notifications.get_event_preference(user_id, guild_id, exact_name)
+
+    view = NotificationSettingsView(
+        user_id=user_id,
+        guild_id=guild_id,
+        event_name=exact_name,
+        current_pref=current_pref
+    )
+
+    status = "enabled" if current_pref else "not set up"
+
+    await interaction.response.send_message(
+        f"🔔 **Notification Settings for {exact_name}**\n\n"
+        f"Current status: {status}\n\n"
+        f"Configure when you want to be notified:",
+        view=view,
+        ephemeral=True
+    )
+
+
+async def quick_enable_notifications(
+    interaction: discord.Interaction,
+    event_name: str
+):
+    """
+    Quickly enable default notifications for an event.
+
+    Called from bulletin NotifyMe button for fast signup.
+    """
+    guild_id = interaction.guild_id
+    user_id = interaction.user.id
+
+    # Check if already enabled
+    current_pref = notifications.get_event_preference(user_id, guild_id, event_name)
+
+    if current_pref:
+        # Already enabled - show settings to modify
+        await show_notification_settings(interaction, event_name)
+        return
+
+    # Enable with defaults
+    pref = notifications.NotificationPreference(
+        user_id=user_id,
+        guild_id=guild_id,
+        event_name=event_name,
+    )
+    notifications.set_notification_preference(pref)
+
+    await interaction.response.send_message(
+        f"✅ **Notifications enabled for {event_name}!**\n\n"
+        f"You'll be notified:\n"
+        f"• ⏰ 1 hour before the event\n"
+        f"• 🎉 When the event starts\n"
+        f"• 📝 If the event changes\n"
+        f"• ❌ If the event is canceled\n\n"
+        f"Use `/remindme {event_name}` to customize these settings.",
+        ephemeral=True
+    )

--- a/core/bulletins.py
+++ b/core/bulletins.py
@@ -373,11 +373,8 @@ class NotifyMeButton(Button):
         super().__init__(label=button_label, style=button_style, custom_id=custom_id)
 
     async def callback(self, interaction: discord.Interaction):
-        await interaction.response.send_message(
-        content=f"⚠️ **OOPS!**\nIt appears this feature is still under construction.",
-        view=None,
-        ephemeral=True
-        )
+        from commands.user import notifications as notif_commands
+        await notif_commands.quick_enable_notifications(interaction, self.event_name)
 
 class RegisterSlotButton(Button):
     def __init__(self, event_name, slot_time: str, emoji_index: str):

--- a/core/conf.py
+++ b/core/conf.py
@@ -19,6 +19,11 @@ class ServerConfigState:
     bulletin_settings_enabled: bool = False
     display_settings_enabled: bool = True
 
+    # Notification settings
+    notifications_enabled: bool = True
+    default_reminder_minutes: int = 60  # 1 hour before
+    notification_channel: Optional[str] = None  # Channel for server-wide announcements
+
     def __post_init__(self):
         self.admin_roles = self.admin_roles or []
         self.event_organizer_roles = self.event_organizer_roles or []
@@ -30,6 +35,8 @@ class ServerConfigState:
             self.bulletin_settings_enabled = False
         if self.display_settings_enabled is None:
             self.display_settings_enabled = True
+        if self.notifications_enabled is None:
+            self.notifications_enabled = True
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -40,7 +47,10 @@ class ServerConfigState:
             "bulletin_channel": self.bulletin_channel,
             "roles_and_permissions_settings_enabled": self.roles_and_permissions_settings_enabled,
             "bulletin_settings_enabled": self.bulletin_settings_enabled,
-            "display_settings_enabled": self.display_settings_enabled
+            "display_settings_enabled": self.display_settings_enabled,
+            "notifications_enabled": self.notifications_enabled,
+            "default_reminder_minutes": self.default_reminder_minutes,
+            "notification_channel": self.notification_channel,
         }
 
     @staticmethod
@@ -53,7 +63,10 @@ class ServerConfigState:
             bulletin_channel=data.get("bulletin_channel", None),
             roles_and_permissions_settings_enabled=data.get("roles_and_permissions_settings_enabled", True),
             bulletin_settings_enabled=data.get("bulletin_settings_enabled", False),
-            display_settings_enabled=data.get("display_settings_enabled", True)
+            display_settings_enabled=data.get("display_settings_enabled", True),
+            notifications_enabled=data.get("notifications_enabled", True),
+            default_reminder_minutes=data.get("default_reminder_minutes", 60),
+            notification_channel=data.get("notification_channel", None),
         )
 
 

--- a/core/notifications.py
+++ b/core/notifications.py
@@ -1,0 +1,507 @@
+"""
+Notification system for Event Bot.
+
+Handles scheduling and sending notifications for:
+- Event reminders (configurable time before event)
+- Event start notifications
+- Event canceled/changed notifications
+"""
+import asyncio
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from enum import Enum
+from typing import Dict, List, Optional, Set, Any, Union
+import discord
+
+from core.storage import read_json, write_json_atomic
+from core.logging import get_logger, log_user_action
+
+logger = get_logger(__name__)
+
+NOTIFICATIONS_FILE = "notifications.json"
+
+
+# =============================================================================
+# Notification Types
+# =============================================================================
+
+class NotificationType(Enum):
+    """Types of notifications the bot can send."""
+    EVENT_REMINDER = "event_reminder"       # Reminder before event starts
+    EVENT_START = "event_start"             # When event starts
+    EVENT_CANCELED = "event_canceled"       # When event is canceled
+    EVENT_CHANGED = "event_changed"         # When event details change
+    EVENT_CONFIRMED = "event_confirmed"     # When event date is confirmed
+
+
+# =============================================================================
+# Data Models
+# =============================================================================
+
+@dataclass
+class NotificationPreference:
+    """User's notification preferences for an event."""
+    user_id: int
+    guild_id: int
+    event_name: str
+    reminder_minutes: int = 60  # Default: 1 hour before
+    notify_on_start: bool = True
+    notify_on_change: bool = True
+    notify_on_cancel: bool = True
+    created_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "user_id": self.user_id,
+            "guild_id": self.guild_id,
+            "event_name": self.event_name,
+            "reminder_minutes": self.reminder_minutes,
+            "notify_on_start": self.notify_on_start,
+            "notify_on_change": self.notify_on_change,
+            "notify_on_cancel": self.notify_on_cancel,
+            "created_at": self.created_at,
+        }
+
+    @staticmethod
+    def from_dict(data: Dict[str, Any]) -> "NotificationPreference":
+        return NotificationPreference(
+            user_id=data["user_id"],
+            guild_id=data["guild_id"],
+            event_name=data["event_name"],
+            reminder_minutes=data.get("reminder_minutes", 60),
+            notify_on_start=data.get("notify_on_start", True),
+            notify_on_change=data.get("notify_on_change", True),
+            notify_on_cancel=data.get("notify_on_cancel", True),
+            created_at=data.get("created_at", datetime.utcnow().isoformat()),
+        )
+
+
+@dataclass
+class ScheduledNotification:
+    """A notification scheduled to be sent at a specific time."""
+    id: str
+    notification_type: NotificationType
+    user_id: int
+    guild_id: int
+    event_name: str
+    scheduled_time: str  # ISO format
+    message: str
+    sent: bool = False
+    created_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "notification_type": self.notification_type.value,
+            "user_id": self.user_id,
+            "guild_id": self.guild_id,
+            "event_name": self.event_name,
+            "scheduled_time": self.scheduled_time,
+            "message": self.message,
+            "sent": self.sent,
+            "created_at": self.created_at,
+        }
+
+    @staticmethod
+    def from_dict(data: Dict[str, Any]) -> "ScheduledNotification":
+        return ScheduledNotification(
+            id=data["id"],
+            notification_type=NotificationType(data["notification_type"]),
+            user_id=data["user_id"],
+            guild_id=data["guild_id"],
+            event_name=data["event_name"],
+            scheduled_time=data["scheduled_time"],
+            message=data["message"],
+            sent=data.get("sent", False),
+            created_at=data.get("created_at", datetime.utcnow().isoformat()),
+        )
+
+
+# =============================================================================
+# Storage Functions
+# =============================================================================
+
+def load_notifications() -> Dict[str, Any]:
+    """Load notifications data from storage."""
+    try:
+        return read_json(NOTIFICATIONS_FILE)
+    except FileNotFoundError:
+        return {"preferences": {}, "scheduled": []}
+
+
+def save_notifications(data: Dict[str, Any]) -> None:
+    """Save notifications data to storage."""
+    write_json_atomic(NOTIFICATIONS_FILE, data)
+
+
+# =============================================================================
+# Preference Management
+# =============================================================================
+
+def get_user_preferences(user_id: int, guild_id: int) -> Dict[str, NotificationPreference]:
+    """
+    Get all notification preferences for a user in a guild.
+
+    Returns:
+        Dict mapping event_name -> NotificationPreference
+    """
+    data = load_notifications()
+    key = f"{guild_id}:{user_id}"
+    prefs = data.get("preferences", {}).get(key, {})
+    return {
+        event_name: NotificationPreference.from_dict(pref)
+        for event_name, pref in prefs.items()
+    }
+
+
+def get_event_preference(user_id: int, guild_id: int, event_name: str) -> Optional[NotificationPreference]:
+    """Get a user's notification preference for a specific event."""
+    prefs = get_user_preferences(user_id, guild_id)
+    return prefs.get(event_name)
+
+
+def set_notification_preference(preference: NotificationPreference) -> None:
+    """Set or update a user's notification preference for an event."""
+    data = load_notifications()
+    key = f"{preference.guild_id}:{preference.user_id}"
+
+    if "preferences" not in data:
+        data["preferences"] = {}
+    if key not in data["preferences"]:
+        data["preferences"][key] = {}
+
+    data["preferences"][key][preference.event_name] = preference.to_dict()
+    save_notifications(data)
+
+    log_user_action(
+        "set_notification",
+        preference.user_id,
+        preference.guild_id,
+        event_name=preference.event_name,
+        reminder_minutes=preference.reminder_minutes
+    )
+
+
+def remove_notification_preference(user_id: int, guild_id: int, event_name: str) -> bool:
+    """Remove a user's notification preference for an event."""
+    data = load_notifications()
+    key = f"{guild_id}:{user_id}"
+
+    if key in data.get("preferences", {}) and event_name in data["preferences"][key]:
+        del data["preferences"][key][event_name]
+        if not data["preferences"][key]:
+            del data["preferences"][key]
+        save_notifications(data)
+        return True
+    return False
+
+
+def get_users_to_notify(guild_id: int, event_name: str) -> List[NotificationPreference]:
+    """Get all users who want notifications for an event."""
+    data = load_notifications()
+    users = []
+
+    for key, prefs in data.get("preferences", {}).items():
+        if key.startswith(f"{guild_id}:"):
+            if event_name in prefs:
+                users.append(NotificationPreference.from_dict(prefs[event_name]))
+
+    return users
+
+
+# =============================================================================
+# Notification Sending
+# =============================================================================
+
+async def send_dm_notification(
+    client: discord.Client,
+    user_id: int,
+    message: str,
+    embed: Optional[discord.Embed] = None
+) -> bool:
+    """
+    Send a DM notification to a user.
+
+    Returns:
+        True if sent successfully, False otherwise
+    """
+    try:
+        user = await client.fetch_user(user_id)
+        if user:
+            await user.send(content=message, embed=embed)
+            logger.info(f"Sent DM notification to user {user_id}")
+            return True
+    except discord.Forbidden:
+        logger.warning(f"Cannot send DM to user {user_id} - DMs disabled")
+    except discord.HTTPException as e:
+        logger.error(f"Failed to send DM to user {user_id}: {e}")
+    return False
+
+
+async def notify_event_reminder(
+    client: discord.Client,
+    guild_id: int,
+    event_name: str,
+    event_time: datetime,
+    registered_users: List[int]
+) -> int:
+    """
+    Send reminder notifications to all registered users.
+
+    Returns:
+        Number of notifications sent successfully
+    """
+    sent_count = 0
+    users_to_notify = get_users_to_notify(guild_id, event_name)
+
+    # Only notify users who are registered for the event
+    registered_set = set(registered_users)
+
+    for pref in users_to_notify:
+        if pref.user_id in registered_set:
+            time_str = f"<t:{int(event_time.timestamp())}:R>"
+            message = (
+                f"⏰ **Reminder:** Your event **{event_name}** starts {time_str}!\n\n"
+                f"Don't forget to check your availability and join when it starts."
+            )
+
+            if await send_dm_notification(client, pref.user_id, message):
+                sent_count += 1
+
+    logger.info(f"Sent {sent_count} reminder notifications for event '{event_name}'")
+    return sent_count
+
+
+async def notify_event_start(
+    client: discord.Client,
+    guild_id: int,
+    event_name: str,
+    registered_users: List[int]
+) -> int:
+    """
+    Send event start notifications to all registered users.
+
+    Returns:
+        Number of notifications sent successfully
+    """
+    sent_count = 0
+    users_to_notify = get_users_to_notify(guild_id, event_name)
+    registered_set = set(registered_users)
+
+    for pref in users_to_notify:
+        if pref.user_id in registered_set and pref.notify_on_start:
+            message = (
+                f"🎉 **{event_name}** is starting now!\n\n"
+                f"Head over to the server to join in."
+            )
+
+            if await send_dm_notification(client, pref.user_id, message):
+                sent_count += 1
+
+    logger.info(f"Sent {sent_count} start notifications for event '{event_name}'")
+    return sent_count
+
+
+async def notify_event_canceled(
+    client: discord.Client,
+    guild_id: int,
+    event_name: str,
+    reason: Optional[str] = None
+) -> int:
+    """
+    Send cancellation notifications to all users who wanted notifications.
+
+    Returns:
+        Number of notifications sent successfully
+    """
+    sent_count = 0
+    users_to_notify = get_users_to_notify(guild_id, event_name)
+
+    for pref in users_to_notify:
+        if pref.notify_on_cancel:
+            message = f"❌ **{event_name}** has been canceled."
+            if reason:
+                message += f"\n\n**Reason:** {reason}"
+
+            if await send_dm_notification(client, pref.user_id, message):
+                sent_count += 1
+
+    # Clean up preferences for this event
+    for pref in users_to_notify:
+        remove_notification_preference(pref.user_id, guild_id, event_name)
+
+    logger.info(f"Sent {sent_count} cancellation notifications for event '{event_name}'")
+    return sent_count
+
+
+async def notify_event_changed(
+    client: discord.Client,
+    guild_id: int,
+    event_name: str,
+    changes: str
+) -> int:
+    """
+    Send change notifications to all users who wanted notifications.
+
+    Returns:
+        Number of notifications sent successfully
+    """
+    sent_count = 0
+    users_to_notify = get_users_to_notify(guild_id, event_name)
+
+    for pref in users_to_notify:
+        if pref.notify_on_change:
+            message = (
+                f"📝 **{event_name}** has been updated!\n\n"
+                f"**Changes:**\n{changes}"
+            )
+
+            if await send_dm_notification(client, pref.user_id, message):
+                sent_count += 1
+
+    logger.info(f"Sent {sent_count} change notifications for event '{event_name}'")
+    return sent_count
+
+
+async def notify_event_confirmed(
+    client: discord.Client,
+    guild_id: int,
+    event_name: str,
+    confirmed_time: datetime
+) -> int:
+    """
+    Send confirmation notifications when an event date is finalized.
+
+    Returns:
+        Number of notifications sent successfully
+    """
+    sent_count = 0
+    users_to_notify = get_users_to_notify(guild_id, event_name)
+
+    time_str = f"<t:{int(confirmed_time.timestamp())}:F>"
+
+    for pref in users_to_notify:
+        message = (
+            f"✅ **{event_name}** has been confirmed!\n\n"
+            f"**Date & Time:** {time_str}\n\n"
+            f"You'll receive a reminder before it starts."
+        )
+
+        if await send_dm_notification(client, pref.user_id, message):
+            sent_count += 1
+
+    logger.info(f"Sent {sent_count} confirmation notifications for event '{event_name}'")
+    return sent_count
+
+
+# =============================================================================
+# Background Scheduler
+# =============================================================================
+
+class NotificationScheduler:
+    """
+    Background task that checks for and sends scheduled notifications.
+
+    This runs as a background task in the Discord bot.
+    """
+
+    def __init__(self, client: discord.Client):
+        self.client = client
+        self.running = False
+        self._task: Optional[asyncio.Task] = None
+
+    def start(self) -> None:
+        """Start the notification scheduler."""
+        if not self.running:
+            self.running = True
+            self._task = asyncio.create_task(self._run())
+            logger.info("Notification scheduler started")
+
+    def stop(self) -> None:
+        """Stop the notification scheduler."""
+        self.running = False
+        if self._task:
+            self._task.cancel()
+            logger.info("Notification scheduler stopped")
+
+    async def _run(self) -> None:
+        """Main scheduler loop."""
+        while self.running:
+            try:
+                await self._check_and_send_notifications()
+            except Exception as e:
+                logger.error(f"Error in notification scheduler: {e}", exc_info=e)
+
+            # Check every minute
+            await asyncio.sleep(60)
+
+    async def _check_and_send_notifications(self) -> None:
+        """Check for pending notifications and send them."""
+        # Import here to avoid circular imports
+        from core import events
+
+        now = datetime.utcnow()
+        all_events = {}
+
+        # Load all events from all guilds
+        events_data = events.load_events()
+        for guild_id, guild_data in events_data.items():
+            for event_name, event in guild_data.get("events", {}).items():
+                all_events[f"{guild_id}:{event_name}"] = event
+
+        # Check each event for notifications to send
+        for key, event in all_events.items():
+            guild_id = int(event.guild_id)
+
+            # Skip events without confirmed dates
+            if not event.confirmed_date or event.confirmed_date == "TBD":
+                continue
+
+            # Parse confirmed date (assuming ISO format)
+            try:
+                event_time = datetime.fromisoformat(event.confirmed_date)
+            except ValueError:
+                continue
+
+            # Get users who want notifications
+            users = get_users_to_notify(guild_id, event.event_name)
+
+            for pref in users:
+                # Check if we should send a reminder
+                reminder_time = event_time - timedelta(minutes=pref.reminder_minutes)
+
+                # If reminder time is within the last minute, send it
+                if reminder_time <= now < reminder_time + timedelta(minutes=1):
+                    await notify_event_reminder(
+                        self.client,
+                        guild_id,
+                        event.event_name,
+                        event_time,
+                        [int(uid) for uid in event.rsvp]
+                    )
+
+                # If event is starting now (within last minute), send start notification
+                if event_time <= now < event_time + timedelta(minutes=1):
+                    await notify_event_start(
+                        self.client,
+                        guild_id,
+                        event.event_name,
+                        [int(uid) for uid in event.rsvp]
+                    )
+
+
+# Global scheduler instance (initialized when bot starts)
+_scheduler: Optional[NotificationScheduler] = None
+
+
+def init_scheduler(client: discord.Client) -> NotificationScheduler:
+    """Initialize and start the notification scheduler."""
+    global _scheduler
+    _scheduler = NotificationScheduler(client)
+    _scheduler.start()
+    return _scheduler
+
+
+def get_scheduler() -> Optional[NotificationScheduler]:
+    """Get the notification scheduler instance."""
+    return _scheduler


### PR DESCRIPTION
This PR adds a complete notification system for event reminders and updates.

## New Files

| File | Purpose |
|------|---------|
| `core/notifications.py` | Notification data models, storage, sending, and background scheduler | | `commands/user/notifications.py` | User-facing notification settings UI and commands |

## Features Added

### User Notifications
- **Event Reminders**: Configurable DM reminders (15min, 30min, 1hr, 2hr, 1 day before)
- **Event Start**: DM when event begins
- **Event Changes**: DM when event details are modified
- **Event Canceled**: DM when event is deleted/canceled

### Notification Settings UI
- `/remindme <event>` - Opens notification settings dialog
- Toggle individual notification types (start, changes, canceled)
- Select reminder timing
- Enable/disable all notifications for an event

### "Notify Me" Button
- Bulletin "Notify Me" button now works!
- One-click to enable default notifications
- Links to `/remindme` for customization

### Background Scheduler
- `NotificationScheduler` runs every 60 seconds
- Checks for events with confirmed times
- Sends reminders at configured intervals before event
- Sends start notifications when event begins

### Server Configuration
- Added `notifications_enabled` toggle
- Added `default_reminder_minutes` setting
- Added `notification_channel` for server-wide announcements (future use)

## Modified Files

| File | Changes |
|------|---------|
| `bot.py` | Added notification imports, updated `/remindme` command, start scheduler on ready | | `core/bulletins.py` | "Notify Me" button now calls notification system | | `core/conf.py` | Added notification settings to ServerConfigState | | `commands/event/manage.py` | Event deletion now sends cancellation notifications |

## Usage

```
/remindme "Game Night"     # Opens notification settings for "Game Night"
```

Or click "Notify Me" on any event bulletin to quickly enable notifications.